### PR TITLE
feat(client): add support for qbox statebags

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -1,6 +1,7 @@
 -- CC SCRIPTS / HUD
 
 local QBCore = exports['qb-core']:GetCoreObject()
+local serverId = GetPlayerServerId(PlayerId())
 local PlayerData = QBCore.Functions.GetPlayerData()
 local config = Config
 local UIConfig = UIConfig
@@ -636,8 +637,20 @@ RegisterNetEvent('hud:client:UpdateNeeds', function(newHunger, newThirst) -- Tri
     thirst = newThirst
 end)
 
+AddStateBagChangeHandler('hunger', ('player:%s'):format(serverId), function(_, _, value)
+    hunger = value
+end)
+
+AddStateBagChangeHandler('thirst', ('player:%s'):format(serverId), function(_, _, value)
+    thirst = value
+end)
+
 RegisterNetEvent('hud:client:UpdateStress', function(newStress) -- Add this event with adding stress elsewhere
     stress = newStress
+end)
+
+AddStateBagChangeHandler('stress', ('player:%s'):format(serverId), function(_, _, value)
+    stress = value
 end)
 
 RegisterNetEvent('hud:client:ToggleShowSeatbelt', function()


### PR DESCRIPTION
This adds support for statebag hunger/thirst/stress when used with qbox and removes dependence on the net events.